### PR TITLE
bug with long form category resolved, now takes category from form

### DIFF
--- a/client/app/controllers/addProductCtrl.js
+++ b/client/app/controllers/addProductCtrl.js
@@ -34,11 +34,13 @@ app.controller('addProductCtrl', function($scope, addProductFactory, $location, 
 
 //function to add products
  $scope.addProduct = ()=> {
-
+    let categoryVal = $("select.longFormCat").val();
+    $scope.product.category = categoryVal;
+     console.log("category", $scope.product.category);
     //test to make sure at least one american checkbox is true
     if ($scope.product.uscompany || $scope.product.usassembled || $scope.product.usmanufactured) {
      //if not in our category, error message
-     if($scope.product.category === "other"){
+     if($scope.product.category === "Other") {
         //alert the user product not in our wheelhouse
         // Materialize.toast(message, displayLength, className, completeCallback);
         Materialize.toast("That product sounds awesome, but it doesn't fit in with other items.", 4000, 'round right'); // 4000 is the duration of the toast

--- a/client/partials/addProduct.html
+++ b/client/partials/addProduct.html
@@ -45,7 +45,7 @@
       </div>
       <div class="row">
           <div class="input-field col s12">
-            <select ng-model="product.category" required>
+            <select class="longFormCat" ng-model="product.category" required>
               <option value="" selected disabled>Select Product Category</option>
               <option value="Home">Home</option>
               <option value="Clothing">Clothing</option>


### PR DESCRIPTION
The materialize styling of the select prevented ng-model from working to gather info from the select form.  Used jQuery to over come. Long form category is now stored to product object, and will fire errors if the product isn't in the 3 categories of the site.